### PR TITLE
Made sticky translate on 1ms scrolls

### DIFF
--- a/src/iscroll-sticky.coffee
+++ b/src/iscroll-sticky.coffee
@@ -25,6 +25,8 @@ window.IScrollSticky = class IScrollSticky
       @refresh()
     @iscroll.on 'scroll', =>
       @translate()
+    @iscroll.on 'scrollEnd' =>
+      @translate();
 
     @iscroll.refresh()
 


### PR DESCRIPTION
Previously scrolls had to last ~75ms for reliable sticky placement. This fixes the issue for scrolls of greater than or equal to 1ms
